### PR TITLE
Fix links in webhooks page

### DIFF
--- a/docs/webhooks.md
+++ b/docs/webhooks.md
@@ -23,9 +23,9 @@ Full information about the available events and their associated payloads can be
 
 | Flow | Event | Trigger |
 | - | - | - |
-| [crypto_onramp](./flows/crypto-onramp) | [`order:crypto-onramp:charged`](./flows/crypto-onramp#ordercrypto-onrampcharged) | User has been charged for their order. |
-| [crypto_onramp](./flows/crypto-onramp) | [`order:crypto-onramp:completed`](./flows/crypto-onramp#ordercrypto-onrampcompleted) | User's order has completed. |
-| [crypto_onramp](./flows/crypto-onramp) | [`order:crypto-onramp:failed`](./flows/crypto-onramp#ordercrypto-onrampfailed) | User's order has failed. |
+| [crypto_onramp](./flows/crypto-onramp.mdx) | [`order:crypto-onramp:charged`](./flows/crypto-onramp.mdx#ordercrypto-onrampcharged) | User has been charged for their order. |
+| [crypto_onramp](./flows/crypto-onramp.mdx) | [`order:crypto-onramp:completed`](./flows/crypto-onramp.mdx#ordercrypto-onrampcompleted) | User's order has completed. |
+| [crypto_onramp](./flows/crypto-onramp.mdx) | [`order:crypto-onramp:failed`](./flows/crypto-onramp.mdx#ordercrypto-onrampfailed) | User's order has failed. |
 
 ## Verifying a request
 


### PR DESCRIPTION
### Description

Links to events where not correct if you access https://docs.topperpay.com/webhooks/ directly and click the links.
Now it does, see: https://f291b0cf.topper-docs.pages.dev/webhooks/

### Related issues

N/A
