### PR TITLE
Simplify standards check github action

### DIFF
--- a/.github/workflows/standards-check.yml
+++ b/.github/workflows/standards-check.yml
@@ -3,22 +3,12 @@ name: Standards Check
 on:
   pull_request:
     types: [opened, synchronize]
+    branches-ignore:
+    - 'dependabot/**'
 
 jobs:
   run-checks:
     runs-on: ubuntu-latest
 
     steps:
-    - id: checkout-standards-check-action
-      uses: actions/checkout@v3
-      with:
-        repository: uphold/standards-check-action
-        ref: v1
-        token: ${{ secrets.ACTIONS_CHECKOUT_TOKEN_GITHUB }}
-        persist-credentials: false
-        path: ./.github/actions/standards-check-action
-
-    - if: steps.checkout-standards-check-action.conclusion == 'success'
-      uses: ./.github/actions/standards-check-action
-      with:
-        auto-labelling: false
+    - uses: uphold/standards-check-action@v1


### PR DESCRIPTION
This is an automated pull-request to simplify the standards check github action. The clone is no longer necessary since we now have Enterprise plan which includes running private github actions.