### PR TITLE
Add reference to `continueUrlTarget` on bootstrap token payload

### DIFF
--- a/docs/flows/crypto-onramp.mdx
+++ b/docs/flows/crypto-onramp.mdx
@@ -2,9 +2,8 @@
 sidebar_position: 1
 ---
 
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
-
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
 
 # Crypto on-ramp
 
@@ -20,6 +19,10 @@ The crypto on-ramp flow allows a user to add funds from a credit or debit card t
   - `fee` (_optional_): An object configuring the partner fee to be charged.
     - `percentage`: Percentage of the total source amount (the maximum allowed value is "5").
   - `continueUrl` (_optional_): URL to redirect the user to after the order is placed.
+  - `continueUrlTarget` (_optional_): In which tab should the `continueUrl` be opened.
+    - `new-tab`: Open in a a new tab.
+    - `same-tab`: Open in the same page or iframe (default).
+    - `parent-tab`: Useful only in an iframe, open in the page that contains the iframe.
 - `partnerFee` (_deprecated_): Use `partner.fee` instead.
 - `source` (_optional_): An object configuring the asset and amount to be paid.
   - `amount` (_optional_): Amount to be paid.
@@ -63,7 +66,8 @@ We recommend that you use `XRP` for testing purposes when integrating Topper sin
     "fee": {
       "percentage": "1"
     },
-    "continueUrl": "https://example.com"
+    "continueUrl": "https://example.com",
+    "continueUrlTarget": "new-tab"
   },
   "source": {
     "amount": "100.00",
@@ -151,8 +155,6 @@ When `recipientEditMode` is `all-editable`, the user can change `asset`, `networ
 </Tabs>
 
 ## Events
-
-
 
 ### `order:crypto-onramp:committed`
 


### PR DESCRIPTION
### Description

This PR adds reference to `continueUrlTarget` on bootstrap token payload.

### Related issues

https://uphold.atlassian.net/browse/SWY-1909
Blocked by: https://github.com/uphold/topper-backend/pull/743
