### PR TITLE
Add KYC sharing reference

### DIFF
--- a/docs/kyc-shaing.md
+++ b/docs/kyc-shaing.md
@@ -1,0 +1,10 @@
+---
+sidebar_position: 16
+---
+
+# KYC sharing
+
+To enhance the user experience we offer a REST API that our partners can use in order to share user KYC processes.
+This will improve the user experience when reaching Topper. If we can gather more information from our partners, Topper will need to request less information from the user, smoothing the sign-up process.
+
+Please check the [Uphold Enterprise API](https://developer.uphold.com/rest-apis/core-api/kyc/introduction) to learn more about this feature.

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 12
+sidebar_position: 15
 ---
 
 # Security


### PR DESCRIPTION
### Description

This PR adds a small reference to the KYC sharing, redirecting to Enterprise API docs for more.
This should only be merged after https://github.com/uphold/topper-backend/pull/1095.
### Related issues

- https://uphold.atlassian.net/browse/SWY-2551
