### PR TITLE
Document `simulation.country` session properties for onramp/offramp flows

### DIFF
--- a/docs/flows/crypto-offramp.mdx
+++ b/docs/flows/crypto-offramp.mdx
@@ -29,6 +29,8 @@ The crypto off-ramp flow allows a user to sell cryptocurrency and convert it int
     - `type`: Tag type (e.g.: `memo` or `destination-tag`).
     - `value`: Tag value.
   - `priority` (_optional_): Priority of the crypto transaction (e.g.: `fast` will enable instant send for `Dash` transactions). Defaults to `normal`.
+- `simulation` (_optional_): Simulation object.
+  - `country` (_optional_): Country to use during simulations, in alpha-2 code format; It will be ignored after the user is authenticated and the user's country will be used.
 - `source` (_optional_): An object configuring the asset and amount to be sold.
   - `allowedAssets` (_optional_): Set of cryptoassets that the user can set as source asset.
   - `amount` (_optional_): Amount to be sold.
@@ -86,6 +88,9 @@ We recommend that you use `XRP` for testing purposes when integrating Topper sin
   "refund": {
     "address": "0xb794f5ea0ba39494ce839613fffba74279579268",
     "priority": "normal"
+  },
+  "simulation": {
+    "country": "US"
   },
   "source": {
     "allowedAssets": [

--- a/docs/flows/crypto-onramp.mdx
+++ b/docs/flows/crypto-onramp.mdx
@@ -24,6 +24,8 @@ The crypto on-ramp flow allows a user to add funds from a credit or debit card t
     - `same-tab`: Open in the same tab or iframe (default).
     - `parent-tab`: Useful only in an iframe: open in the tab that contains the iframe.
 - `partnerFee` (_deprecated_): Use `partner.fee` instead.
+- `simulation` (_optional_): Simulation object.
+  - `country` (_optional_): Country to use during simulations, in alpha-2 code format; It will be ignored after the user is authenticated and the user's country will be used.
 - `source` (_optional_): An object configuring the asset and amount to be paid.
   - `amount` (_optional_): Amount to be paid.
   - `asset`: Currency code in the [ISO 4217](https://www.iso.org/iso-4217-currency-codes.html) format used to make the payment.
@@ -75,6 +77,9 @@ We recommend that you use `XRP` for testing purposes when integrating Topper sin
     },
     "continueUrl": "https://example.com",
     "continueUrlTarget": "new-tab"
+  },
+  "simulation": {
+    "country": "US"
   },
   "source": {
     "amount": "100.00",


### PR DESCRIPTION
### Description

This PR document `simulation.country` session properties for onramp/offramp flows

### Related issues

https://uphold.atlassian.net/browse/SWY-3131

Blocked by:
- https://github.com/uphold/topper-backend/pull/1374

It should be merged when dynamic priding per country is implemented.
